### PR TITLE
Remove unknown profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,6 @@ no_std_sp1 = ["sha2-sp1", "sha3-sp1", "crypto-bigint-sp1", "p256-sp1"]
 runner = ["no_std", "tokio", "axum", "base64", "serde"]
 runner_sp1 = ["sp1-sdk"]
 
-[profile.dev.package.interliquid-sdk]
-features = ["runner", "runner_sp1"]
-
-[profile.test.package.interliquid-sdk]
-features = ["runner", "runner_sp1"]
-
 [[example]]
 name = "basic_usage"
 path = "examples/basic_usage.rs"


### PR DESCRIPTION
![Capture d’écran du 2025-06-16 11-01-50](https://github.com/user-attachments/assets/70f273dd-b280-4533-adea-dc70542d609d)

As described at https://doc.rust-lang.org/cargo/reference/profiles.html, profiles are used to tune code generation rather than manage Cargo resources.